### PR TITLE
Multiple timers, optional callbacks and initial state option.

### DIFF
--- a/src/timer.jquery.js
+++ b/src/timer.jquery.js
@@ -29,6 +29,11 @@
 				alert('Time up!');
 				stopTimerInterval();
 			},
+      startTimer: function() {},
+      pauseTimer: function() {},
+      resumeTimer: function() {},
+      resetTimer: function() {},
+      removeTimer: function() {},
 			repeat: false,								// this will repeat callback every n times duration is elapsed
 			countdown: false,							// if true, this will render the timer as a countdown if duration > 0
 			format: null,								// this sets the format in which the time will be printed
@@ -257,6 +262,7 @@
 			render();
 			startTimerInterval();
 			$el.data('state', TIMER_RUNNING);
+      options.startTimer($el);
 		}
 	}
 
@@ -264,6 +270,7 @@
 		if (isTimerRunning) {
 			stopTimerInterval();
 			$el.data('state', TIMER_PAUSED);
+      options.pauseTimer($el);
 		}
 	}
 
@@ -272,10 +279,12 @@
 			startTime = getUnixSeconds() - totalSeconds;
 			startTimerInterval();
 			$el.data('state', TIMER_RUNNING);
+      options.resumeTimer($el);
 		}
 	}
 
 	function resetTimer() {
+    options.resetTimer($el);
 		startTime = getUnixSeconds();
 		totalSeconds = 0;
 		$el.data('seconds', totalSeconds);
@@ -285,6 +294,7 @@
 
 	function removeTimer() {
 		stopTimerInterval();
+    options.removeTimer($el);
 		$el.data('plugin_' + pluginName, null);
 		$el.data('seconds', null);
 		$el.data('state', null);
@@ -392,7 +402,12 @@
 			 * Allow passing custom options object
 			 */
 			if (typeof options === 'object') {
-				instance.start.call(instance);
+        if (options.state == TIMER_RUNNING) {
+  				instance.start.call(instance);
+        }
+        else {
+          render();
+        }
 			}
 		});
 	};

--- a/src/timer.jquery.js
+++ b/src/timer.jquery.js
@@ -338,7 +338,7 @@
 		}
 
 		if (this.options.editable) {
-			makeEditable(timer);
+			makeEditable(this);
 		}
 
 	};

--- a/src/timer.jquery.js
+++ b/src/timer.jquery.js
@@ -29,11 +29,11 @@
 				alert('Time up!');
 				stopTimerInterval();
 			},
-      startTimer: function() {},
-      pauseTimer: function() {},
-      resumeTimer: function() {},
-      resetTimer: function() {},
-      removeTimer: function() {},
+			startTimer: function() {},
+			pauseTimer: function() {},
+			resumeTimer: function() {},
+			resetTimer: function() {},
+			removeTimer: function() {},
 			repeat: false,								// this will repeat callback every n times duration is elapsed
 			countdown: false,							// if true, this will render the timer as a countdown if duration > 0
 			format: null,								// this sets the format in which the time will be printed
@@ -50,7 +50,7 @@
 	 * Common function to start or resume a timer interval
 	 */
 	function startTimerInterval(timer) {
-    var element = timer.element;
+		var element = timer.element;
 		$(element).data('intr', setInterval(incrementSeconds.bind(timer), timer.options.updateFrequency));
 		$(element).data('isTimerRunning', true);
 	}
@@ -79,7 +79,7 @@
 			// If 'repeat' is not requested then disable the duration
 			if (!this.options.repeat) {
 				$(this.element).data('duration', null);
-        this.options.duration = null;
+				this.options.duration = null;
 			}
 
 			// If this is a countdown, then end it as duration has completed
@@ -93,7 +93,7 @@
 	 * Render pretty time
 	 */
 	function render(timer) {
-    var element = timer.element;
+		var element = timer.element;
 		var sec = $(element).data('totalSeconds');
 
 		if (timer.options.countdown && $(element).data('duration') > 0) {
@@ -114,7 +114,7 @@
 	 * to blur and focus.
 	 */
 	function makeEditable(timer) {
-    var element = timer.element;
+		var element = timer.element;
 		$(element).on('focus', function() {
 			pauseTimer(timer);
 		});
@@ -262,37 +262,37 @@
 
 	// TIMER INTERFACE
 	function startTimer(timer) {
-    var element = timer.element;
+		var element = timer.element;
 		if (!$(element).data('isTimerRunning')) {
 			render(timer);
 			startTimerInterval(timer);
 			$(element).data('state', TIMER_RUNNING);
-      timer.options.startTimer.bind(timer).call();
+			timer.options.startTimer.bind(timer).call();
 		}
 	}
 
 	function pauseTimer(timer) {
-    var element = timer.element;
+		var element = timer.element;
 		if ($(element).data('isTimerRunning')) {
 			stopTimerInterval(timer);
 			$(element).data('state', TIMER_PAUSED);
-      timer.options.pauseTimer.bind(timer).call();
+			timer.options.pauseTimer.bind(timer).call();
 		}
 	}
 
 	function resumeTimer(timer) {
-    var element = timer.element;
+		var element = timer.element;
 		if (!$(element).data('isTimerRunning')) {
 			$(element).data('startTime', getUnixSeconds() - $(element).data('totalSeconds'));
 			startTimerInterval(timer);
 			$(element).data('state', TIMER_RUNNING);
-      timer.options.resumeTimer.bind(timer).call();
+			timer.options.resumeTimer.bind(timer).call();
 		}
 	}
 
 	function resetTimer(timer) {
-    var element = timer.element;
-    timer.options.resetTimer().bind(timer).call();
+		var element = timer.element;
+		timer.options.resetTimer().bind(timer).call();
 		$(element).data('startTime', getUnixSeconds());
 		$(element).data('totalSeconds', 0);
 		$(element).data('seconds', $(element).data('totalSeconds'));
@@ -301,9 +301,9 @@
 	}
 
 	function removeTimer(timer) {
-    var element = timer.element;
+		var element = timer.element;
 		stopTimerInterval(timer);
-    timer.options.removeTimer.bind(timer).call();
+		timer.options.removeTimer.bind(timer).call();
 		$(element).data('plugin_' + pluginName, null);
 		$(element).data('seconds', null);
 		$(element).data('state', null);
@@ -315,7 +315,7 @@
 		var elementType;
 
 		this.options = options = $.extend(options, userOptions);
-    this.element = element;
+		this.element = element;
 
 		// Setup total seconds from options.seconds (if any)
 		$(element).data('totalSeconds', options.seconds);
@@ -334,7 +334,7 @@
 
 		if (this.options.duration) {
 			$(element).data('duration', timeToSeconds(this.options.duration));
-      this.options.duration = timeToSeconds(this.options.duration);
+			this.options.duration = timeToSeconds(this.options.duration);
 		}
 
 		if (this.options.editable) {
@@ -412,12 +412,12 @@
 			 * Allow passing custom options object
 			 */
 			if (typeof options === 'object') {
-        if (instance.options.state == TIMER_RUNNING) {
-  				instance.start.call(instance);
-        }
-        else {
-          render(this);
-        }
+				if (instance.options.state == TIMER_RUNNING) {
+					instance.start.call(instance);
+				}
+				else {
+					render(this);
+				}
 			}
 		});
 	};

--- a/src/timer.jquery.js
+++ b/src/timer.jquery.js
@@ -37,7 +37,8 @@
 			repeat: false,								// this will repeat callback every n times duration is elapsed
 			countdown: false,							// if true, this will render the timer as a countdown if duration > 0
 			format: null,								// this sets the format in which the time will be printed
-			updateFrequency: 1000						// How often should timer display update (default 500ms)
+			updateFrequency: 1000,						// How often should timer display update (default 500ms)
+			state: 'running'
 		},
 		$el,
 		display = 'html',	// to be used as $el.html in case of div and $el.val in case of input type text
@@ -416,7 +417,7 @@
 					instance.start.call(instance);
 				}
 				else {
-					render(this);
+					render(instance);
 				}
 			}
 		});


### PR DESCRIPTION
See https://github.com/walmik/timer.jquery/issues/27.

This pull requests introduces 3 new features:
- Multiple Timers on One Page
- Optional Callbacks on Timer Actions
- Initial state option.

## Multiple Timers
We achieve multiple timers by storing the important variables in the elements data, instead of in the scoped variables. We then bind the interval function to the Timer object so that in can increment the specific element's settings.

We pass a timer object to the resume/pause/start/reset/stopTimer functions so that these can act on the correct timer.

Options are now stored against the Timer object so that the multiple timers can have difference options  including durations and callbacks.

## Optional Callbacks
When creating a new timer, the JS can set functions in the options for each of the main actions. This allows application developers to interact with the timer, for example sending messages to a webservice when I timer is paused/resumed.

## Initial State
By passing 'state' as an option to the timer on creation, the timer can be created initially paused. This is important for timers that have a pauseTimer callback as you would not want this callback to run when initialising a timer.